### PR TITLE
Formalize licensing & package.json

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License
+
+Copyright 2018 UCLA ACM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,8 @@
     "start": "npm run dev",
     "dev": "export NODE_ENV=development && node index.js"
   },
+  "license": "MIT",
+  "private": true,
   "dependencies": {
     "cors": "^2.8.4",
     "express": "^4.16.2",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,6 @@
 {
   "name": "mentorq-client",
   "version": "0.1.0",
-  "private": true,
   "dependencies": {
     "axios": "^0.18.0",
     "material-ui": "^0.20.0",
@@ -20,6 +19,8 @@
   "devDependencies": {
     "react-scripts": "1.0.5"
   },
+  "license": "MIT",
+  "private": true,
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "url": "git+https://github.com/uclaacm/mentorq.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
+  "private": true,
   "bugs": {
     "url": "https://github.com/uclaacm/mentorq/issues"
   },


### PR DESCRIPTION
I'd like to relicense this repo to MIT to avoid the licensing confusion we are currently in. I'm asking all of the following people who have contributed to this repo if they are okay with relicensing:

- [x] @conniec218 
- [x] @dustinnewman98 
- [x] @GalenWong 
- [x] @jeanettelin8 
- [x] @shannonphu 
- [x] myself

See the [MIT License](https://choosealicense.com/licenses/mit/) on what rights you are releasing to the public, as well as other things the MIT License entails. The MIT License is one of the most common licenses used in the JavaScript world and has been popular for many years, and projects like React, Node.js, and many other projects you have heard of use MIT.