### PR TITLE
Fixed double ticket bug with admin and mentors

### DIFF
--- a/api/controllers/SocketController.js
+++ b/api/controllers/SocketController.js
@@ -83,7 +83,7 @@ class SocketController {
 
 		// Notify admins and mentors that there is now a new ticket.
 		this.io.to('admins').emit('action', action);
-		this.io.to('mentors').emit('action', action);
+		this.io.to('mentorsOnly').emit('action', action);
 
 		// Also notify the submitter that their new ticket has been acknowledged.
 		if (!this.user.isAdmin && !this.user.isMentor) {


### PR DESCRIPTION
This PR aims to fix a bug where a ticket is "submitted" twice if any user if both an `admin` and a `mentor`. Basically, we just use the `mentorsOnly` Socket.io room instead of `mentors`.