### PR TITLE
Add notification support

### DIFF
--- a/api/controllers/ReduxStateController.js
+++ b/api/controllers/ReduxStateController.js
@@ -16,7 +16,8 @@ async function getInitialState(io, user) {
 				current: null
 			},
 			socket: {
-				tickets: []
+				tickets: [],
+				pendingTickets: 0
 			}
 		};
 	}
@@ -29,7 +30,8 @@ async function getInitialState(io, user) {
 			current: user
 		},
 		socket: {
-			tickets
+			tickets,
+			pendingTickets: 0
 		}
 	};
 }

--- a/client/src/components/ConnectedNotifier/ConnectedNotifier.jsx
+++ b/client/src/components/ConnectedNotifier/ConnectedNotifier.jsx
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import { Notifier } from '..';
+
+const trigger = (curProps, prevProps, notify) => {
+	if (curProps.pendingTickets < prevProps.pendingTickets) {
+		for (let i = curProps.pendingTickets; i < prevProps.pendingTickets; i++) {
+			notify('Request submitted.');
+		}
+	}
+	const previouslyWaiting = new Set();
+	for (const ticket of prevProps.tickets) {
+		if (ticket.requestorId === prevProps.userId && !ticket.mentorId) {
+			previouslyWaiting.add(ticket._id);
+		}
+	}
+	for (const ticket of curProps.tickets) {
+		if (ticket.mentorId && previouslyWaiting.has(ticket._id)) {
+			notify(`${ticket.mentorName} is on their way!`);
+			break;
+		}
+	}
+};
+
+const ConnectedNotifier = connect(
+	state => ({
+		pendingTickets: state.socket.pendingTickets,
+		tickets: state.socket.tickets,
+		userId: state.user.current && state.user.current._id,
+		trigger
+	})
+)(Notifier);
+
+export default ConnectedNotifier;

--- a/client/src/components/Main/Main.jsx
+++ b/client/src/components/Main/Main.jsx
@@ -6,6 +6,7 @@ import purple from '@material-ui/core/colors/purple';
 
 import {
 	Nav,
+	ConnectedNotifier,
 	ConnectedTicketList,
 	HomeContainer,
 	AdminPanel
@@ -43,6 +44,8 @@ function Main({ isSignedIn, isAdmin }) {
 						isAdmin ? <AdminPanel /> : <Redirect to='/' />
 					} />
 				</Switch>
+
+				<ConnectedNotifier />
 			</div>
 		</MuiThemeProvider>
 	);

--- a/client/src/components/Notifier/Notifier.jsx
+++ b/client/src/components/Notifier/Notifier.jsx
@@ -28,6 +28,9 @@ class Notifier extends Component {
 	addToQueue(message) {
 		this.queue.push({ message, key: Date.now() });
 		if (document.visibilityState === 'hidden') {
+			// Notification class is designed to be used in the following
+			// side-effective way.
+			// eslint-disable-next-line no-new
 			new Notification(message);
 		}
 	}

--- a/client/src/components/Notifier/Notifier.jsx
+++ b/client/src/components/Notifier/Notifier.jsx
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Snackbar from '@material-ui/core/Snackbar';
+
+class Notifier extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			open: false,
+			messageInfo: {
+				message: '',
+				key: 0
+			}
+		};
+		this.queue = [];
+		this.processQueue = this.processQueue.bind(this);
+		this.addToQueue = this.addToQueue.bind(this);
+		this.handleClose = this.handleClose.bind(this);
+	}
+
+	componentDidUpdate(prevProps) {
+		this.props.trigger(this.props, prevProps, this.addToQueue);
+		if (!this.state.open) {
+			this.processQueue();
+		}
+	}
+
+	addToQueue(message) {
+		this.queue.push({ message, key: Date.now() });
+		if (document.visibilityState === 'hidden') {
+			new Notification(message);
+		}
+	}
+
+	processQueue() {
+		if (this.queue.length > 0) {
+			this.setState({
+				open: true,
+				messageInfo: this.queue.shift()
+			});
+		}
+	}
+
+	handleClose(event, reason) {
+		if (reason === 'clickaway') {
+			return;
+		}
+
+		this.setState({ open: false });
+	}
+
+	render() {
+		return <Snackbar
+			key={this.state.messageInfo.key}
+			anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+			open={this.state.open}
+			autoHideDuration={3000}
+			onClose={this.handleClose}
+			onExited={this.processQueue}
+			message={this.state.messageInfo.message}
+		/>;
+	}
+}
+
+Notifier.propTypes = {
+	trigger: PropTypes.func.isRequired
+};
+
+export default Notifier;

--- a/client/src/components/TicketForm/TicketForm.jsx
+++ b/client/src/components/TicketForm/TicketForm.jsx
@@ -10,6 +10,8 @@ import { Code, LocationOn, Phone } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 
+import history from '../../history';
+
 import './TicketForm.css';
 
 const styles = theme => ({
@@ -88,6 +90,7 @@ class TicketForm extends Component {
 				tableNum: this.state.location.value,
 				contactInfo: this.state.contact.value
 			});
+			history.push('tickets');
 		}
 	}
 
@@ -105,7 +108,7 @@ class TicketForm extends Component {
 								<TextField
 									required
 									id="description"
-									label="I need help with..."
+									label="I need help with…"
 									placeholder="Describe your problem"
 									value={this.state.description.value}
 									error={this.state.description.error}
@@ -116,7 +119,6 @@ class TicketForm extends Component {
 											<InputAdornment position="start">
 												<Code />
 											</InputAdornment>
-
 									}}
 								/>
 							</div>
@@ -124,7 +126,7 @@ class TicketForm extends Component {
 								<TextField
 									required
 									id="location"
-									label="You can find me at..."
+									label="You can find me at…"
 									placeholder="where are you? table number?"
 									value={this.state.location.value}
 									error={this.state.location.error}
@@ -135,7 +137,6 @@ class TicketForm extends Component {
 											<InputAdornment position="start">
 												<LocationOn />
 											</InputAdornment>
-
 									}}
 								/>
 							</div>
@@ -143,7 +144,7 @@ class TicketForm extends Component {
 								<TextField
 									required
 									id="contact"
-									label="You can contact me through..."
+									label="You can contact me through…"
 									placeholder="cell phone #"
 									value={this.state.contact.value}
 									error={this.state.contact.error}
@@ -154,11 +155,9 @@ class TicketForm extends Component {
 											<InputAdornment position="start">
 												<Phone />
 											</InputAdornment>
-
 									}}
 								/>
 							</div>
-							<Button onClick={this.onSubmit} fullWidth={true} style={{ display: 'none' }}>x</Button>
 						</form>
 					</CardContent>
 					<CardActions>

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -13,3 +13,5 @@ export { default as ConnectedActiveMentors } from './ConnectedActiveMentors/Conn
 export { default as Login } from './Login/Login';
 export { default as AdminPanel } from './AdminPanel/AdminPanel';
 export { default as SplashPage } from './SplashPage/SplashPage';
+export { default as Notifier } from './Notifier/Notifier';
+export { default as ConnectedNotifier } from './ConnectedNotifier/ConnectedNotifier';

--- a/client/src/history.js
+++ b/client/src/history.js
@@ -1,0 +1,5 @@
+import createBrowserHistory from "history/createBrowserHistory";
+
+const history = createBrowserHistory();
+
+export default history;

--- a/client/src/history.js
+++ b/client/src/history.js
@@ -1,4 +1,4 @@
-import createBrowserHistory from "history/createBrowserHistory";
+import createBrowserHistory from 'history/createBrowserHistory';
 
 const history = createBrowserHistory();
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,23 +1,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 
+import history from './history';
 import store from './store';
 
 // Our own components
 import { App } from './components';
 
-// Register service worker
-import registerServiceWorker from './registerServiceWorker';
 import './index.css'; // Our own main stylesheet
+
+Notification.requestPermission();
 
 const router =
 	<Provider store={store}>
-		<BrowserRouter>
+		<Router history={history}>
 			<App />
-		</BrowserRouter>
+		</Router>
 	</Provider>;
 
 ReactDOM.render(router, document.getElementById('root'));
-registerServiceWorker();

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,5 +1,5 @@
-import UserReducer from './user';
-import SocketReducer from './socket';
+import userReducer from './user';
+import socketReducer from './socket';
 
 // N.B.: Change api/controllers/ReduxStateController.js whenever this is changed.
 function rootReducer(state = {}, action) {
@@ -7,8 +7,8 @@ function rootReducer(state = {}, action) {
 		return action.initialState;
 	}
 	return {
-		user: UserReducer(state.user, action),
-		socket: SocketReducer(state.socket, action, state.user)
+		user: userReducer(state.user, action),
+		socket: socketReducer(state.socket, action, state.user)
 	};
 }
 

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,16 +1,15 @@
-import { combineReducers } from 'redux';
-
 import UserReducer from './user';
 import SocketReducer from './socket';
 
 // N.B.: Change api/controllers/ReduxStateController.js whenever this is changed.
-const combinedReducer = combineReducers({ user: UserReducer, socket: SocketReducer });
-
 function rootReducer(state = {}, action) {
 	if (action.type === 'SOCKET_INITIAL_STATE') {
 		return action.initialState;
 	}
-	return combinedReducer(state, action);
+	return {
+		user: UserReducer(state.user, action),
+		socket: SocketReducer(state.socket, action, state.user)
+	};
 }
 
 export default rootReducer;

--- a/client/src/reducers/socket.js
+++ b/client/src/reducers/socket.js
@@ -1,5 +1,5 @@
 // N.B.: Change api/controllers/ReduxStateController.js whenever this is changed.
-export default function SocketReducer(state = {
+export default function socketReducer(state = {
 	tickets: [],
 	pendingTickets: 0
 }, action, userState = {

--- a/client/src/reducers/socket.js
+++ b/client/src/reducers/socket.js
@@ -1,13 +1,27 @@
 // N.B.: Change api/controllers/ReduxStateController.js whenever this is changed.
 export default function SocketReducer(state = {
-	tickets: []
-}, action) {
+	tickets: [],
+	pendingTickets: 0
+}, action, userState = {
+	current: null
+}) {
 	switch (action.type) {
-	case 'SOCKET_TICKET_NEW': {
+	// When we just submitted a new ticket request.
+	case 'socket/ticket/new': {
 		return {
+			...state,
+			pendingTickets: state.pendingTickets + 1
+		};
+	}
+	case 'SOCKET_TICKET_NEW': {
+		const newState = {
 			...state,
 			tickets: [...state.tickets, action.newTicket]
 		};
+		if (state.pendingTickets && userState.current && action.newTicket.requestorId === userState.current._id) {
+			newState.pendingTickets--;
+		}
+		return newState;
 	}
 	case 'SOCKET_TICKET_CLAIMED': {
 		const {

--- a/client/src/reducers/user.js
+++ b/client/src/reducers/user.js
@@ -1,5 +1,5 @@
 // N.B.: Change api/controllers/ReduxStateController.js whenever this is changed.
-export default function UserReducer(state = { mentors: [], current: null }, action) {
+export default function userReducer(state = { mentors: [], current: null }, action) {
 	switch (action.type) {
 	case 'USER_TEST':
 		return {


### PR DESCRIPTION
Notify the user whenever a mentor claims a ticket, through a newly added snackbar as well as a desktop notification if the current tab is not active.

Additionally, redirect the user to the tickets page when they submit a ticket, as well as show a snackbar notification when the ticket has been submitted.

Also remove unused service worker registration steps.